### PR TITLE
Fix protected SAM device detection

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -172,8 +172,8 @@ static bool cmd_jtag_scan(target *t, int argc, char **argv)
 		irlens[argc-1] = 0;
 	}
 
-	if(connect_assert_srst)
-		platform_srst_set_val(true); /* will be deasserted after attach */
+	platform_srst_set_val(connect_assert_srst);
+    /* will be deasserted before probe and cortexm_attach */
 
 	int devs = -1;
 	volatile struct exception e;
@@ -206,8 +206,8 @@ bool cmd_swdp_scan(target *t, int argc, char **argv)
 	(void)argv;
 	gdb_outf("Target voltage: %s\n", platform_target_voltage());
 
-	if(connect_assert_srst)
-		platform_srst_set_val(true); /* will be deasserted after attach */
+	platform_srst_set_val(connect_assert_srst);
+    /* will be deasserted before probe and attach */
 
 	int devs = -1;
 	volatile struct exception e;

--- a/src/include/command.h
+++ b/src/include/command.h
@@ -34,6 +34,7 @@ int command_process(target *t, char *cmd);
  * gdb port, returns false and leaves out untouched.
  */
 bool parse_enable_or_disable(const char *s, bool *out);
+extern bool connect_assert_srst;
 
 #endif
 

--- a/src/platforms/pc-stlinkv2/adiv5_swdp.c
+++ b/src/platforms/pc-stlinkv2/adiv5_swdp.c
@@ -28,6 +28,7 @@
 #include "target_internal.h"
 #include "adiv5.h"
 #include "stlinkv2.h"
+#include "command.h"
 
 int adiv5_swdp_scan(void)
 {
@@ -35,6 +36,8 @@ int adiv5_swdp_scan(void)
 	ADIv5_DP_t *dp = (void*)calloc(1, sizeof(*dp));
 	if (stlink_enter_debug_swd())
 		return 0;
+	/* stlink_enter_debug_swd releases SRST.*/
+	stlink_srst_set_val(connect_assert_srst);
 	dp->idcode = stlink_read_coreid();
 	dp->dp_read = stlink_dp_read;
 	dp->error = stlink_dp_error;

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -280,17 +280,6 @@ static bool adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr, int recursion, 
 		pidr |= (uint64_t)x << 32;
 	}
 
-	if ((ap->apsel == 0) && (recursion == 0) && (num_entry == 0)) {
-		uint32_t designer = (pidr & 0x7f000) >> 12;
-		designer |= (pidr & 0xf00000000ULL) >> 24;
-		ap->designer = designer;
-		ap->partno = pidr & 0xfff;
-		DEBUG("Designer 0x%03" PRIx32 ", Partno 0x%03" PRIx16 "\n",
-			  designer, ap->partno);
-		if (designer == DESIGNER_STM) {
-			stm32_prepare(ap);
-		}
-	}
 	/* Assemble logical Component ID register value. */
 	for (int i = 0; i < 4; i++) {
 		uint32_t x = adiv5_mem_read32(ap, addr + CIDR0_OFFSET + 4*i);
@@ -324,8 +313,8 @@ static bool adiv5_component_probe(ADIv5_AP_t *ap, uint32_t addr, int recursion, 
 			DEBUG("Fault reading ROM table entry\n");
 		}
 
-		DEBUG("ROM: Table BASE=0x%"PRIx32" SYSMEM=0x%"PRIx32"\n",
-			  addr, memtype);
+		DEBUG("ROM: Table BASE=0x%"PRIx32" SYSMEM=0x%"PRIx32", PIDR 0x%010"
+			  PRIx64 "\n", addr, memtype, pidr);
 #endif
 
 		for (int i = 0; i < 960; i++) {

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -138,9 +138,6 @@ typedef struct ADIv5_DP_s {
 	int refcnt;
 
 	uint32_t idcode;
-	uint32_t dp_idcode; /* Contains DPvX revision*/
-	uint32_t targetid;  /* Contains IDCODE for DPv2 devices.*/
-
 	uint32_t (*dp_read)(struct ADIv5_DP_s *dp, uint16_t addr);
 	uint32_t (*error)(struct ADIv5_DP_s *dp);
 	uint32_t (*low_access)(struct ADIv5_DP_s *dp, uint8_t RnW,

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -183,6 +183,7 @@ typedef struct ADIv5_AP_s {
 	uint32_t csw;
 	uint16_t designer;
 	uint16_t partno;
+	uint32_t demcr; /* DEMCR at entry*/
 	/* Space for device specific values */
 	uint32_t priv1;	/* E.g. Address of DBGMCU_CR for STM32. */
 	uint32_t priv2; /* E.g. Initial value of DBGMCU_CR for STM32. */

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -129,6 +129,10 @@ enum align {
 	ALIGN_DWORD    = 3
 };
 
+/* Some Designers already seen*/
+#define DESIGNER_STM   0x020
+#define DESIGNER_ATMEL 0x01f
+
 /* Try to keep this somewhat absract for later adding SW-DP */
 typedef struct ADIv5_DP_s {
 	int refcnt;
@@ -180,6 +184,11 @@ typedef struct ADIv5_AP_s {
 	uint32_t cfg;
 	uint32_t base;
 	uint32_t csw;
+	uint16_t designer;
+	uint16_t partno;
+	/* Space for device specific values */
+	uint32_t priv1;	/* E.g. Address of DBGMCU_CR for STM32. */
+	uint32_t priv2; /* E.g. Initial value of DBGMCU_CR for STM32. */
 } ADIv5_AP_t;
 
 void adiv5_dp_init(ADIv5_DP_t *dp);

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -278,6 +278,11 @@ bool cortexm_prepare(ADIv5_AP_t *ap)
 			break;
 		}
 		if (delta > cortexm_wait_timeout) {
+			if (ap->designer == DESIGNER_ATMEL) {
+				/* A protected SAMD never sets S_HALT.
+				 * Continue anyways.*/
+				return true;
+			}
 			DEBUG("Halt failed after %" PRIu32 " ms\n", delta);
 			return false;
 		}

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -22,7 +22,7 @@
 #include "target.h"
 #include "adiv5.h"
 
-extern long cortexm_wait_timeout;
+extern uint32_t cortexm_wait_timeout;
 /* Private peripheral bus base address */
 #define CORTEXM_PPB_BASE	0xE0000000
 
@@ -170,6 +170,8 @@ extern long cortexm_wait_timeout;
 
 #define	CORTEXM_TOPT_INHIBIT_SRST (1 << 2)
 
+bool cortexm_prepare(ADIv5_AP_t *ap);
+void cortexm_release(ADIv5_AP_t *ap);
 bool cortexm_probe(ADIv5_AP_t *ap, bool forced);
 ADIv5_AP_t *cortexm_ap(target *t);
 

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -173,7 +173,7 @@ extern uint32_t cortexm_wait_timeout;
 bool cortexm_prepare(ADIv5_AP_t *ap);
 void cortexm_release(ADIv5_AP_t *ap);
 void stm32_prepare(ADIv5_AP_t *ap);
-bool cortexm_probe(ADIv5_AP_t *ap, bool forced);
+bool cortexm_probe(ADIv5_AP_t *ap);
 ADIv5_AP_t *cortexm_ap(target *t);
 
 bool cortexm_attach(target *t);

--- a/src/target/cortexm.h
+++ b/src/target/cortexm.h
@@ -172,6 +172,7 @@ extern uint32_t cortexm_wait_timeout;
 
 bool cortexm_prepare(ADIv5_AP_t *ap);
 void cortexm_release(ADIv5_AP_t *ap);
+void stm32_prepare(ADIv5_AP_t *ap);
 bool cortexm_probe(ADIv5_AP_t *ap, bool forced);
 ADIv5_AP_t *cortexm_ap(target *t);
 

--- a/src/target/lpc11xx.c
+++ b/src/target/lpc11xx.c
@@ -100,6 +100,7 @@ lpc11xx_probe(target *t)
 	}
 
 	idcode = target_mem_read32(t, LPC8XX_DEVICE_ID);
+	DEBUG("LPC11/84: IDCODE 0x%08" PRIx32 "\n", idcode);
 	switch (idcode) {
 	case 0x00008100:  /* LPC810M021FN8 */
 	case 0x00008110:  /* LPC811M001JDH16 */
@@ -117,6 +118,22 @@ lpc11xx_probe(target *t)
 		t->driver = "LPC82x";
 		target_add_ram(t, 0x10000000, 0x2000);
 		lpc11xx_add_flash(t, 0x00000000, 0x8000, 0x400);
+		return true;
+	case 0x00008441:
+	case 0x00008442:
+	case 0x00008443: /* UM11029 Rev.1.4 list 8442 */
+	case 0x00008444:
+		t->driver = "LPC844";
+		target_add_ram(t, 0x10000000, 0x2000);
+		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x400);
+		return true;
+	case 0x00008451:
+	case 0x00008452:
+	case 0x00008453:
+	case 0x00008454:
+		t->driver = "LPC845";
+		target_add_ram(t, 0x10000000, 0x4000);
+		lpc11xx_add_flash(t, 0x00000000, 0x10000, 0x400);
 		return true;
 	case 0x0003D440:	/* LPC11U34/311  */
 	case 0x0001cc40:	/* LPC11U34/421  */

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -88,9 +88,6 @@ static int stm32f1_flash_write(struct target_flash *f,
 #define SR_ERROR_MASK	0x14
 #define SR_EOP		0x20
 
-#define DBGMCU_IDCODE	0xE0042000
-#define DBGMCU_IDCODE_F0	0x40015800
-
 #define FLASHSIZE     0x1FFFF7E0
 #define FLASHSIZE_F0  0x1FFFF7CC
 
@@ -115,9 +112,9 @@ static void stm32f1_add_flash(target *t,
 
 bool stm32f1_probe(target *t)
 {
-	size_t flash_size;
+	size_t flash_size = 0;
 	size_t block_size = 0x400;
-	t->idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xfff;
+	t->idcode = cortexm_ap(t)->partno;
 	switch(t->idcode) {
 	case 0x410:  /* Medium density */
 	case 0x412:  /* Low denisty */
@@ -146,11 +143,7 @@ bool stm32f1_probe(target *t)
 		target_add_ram(t, 0x20000000, 0x10000);
 		stm32f1_add_flash(t, 0x8000000, 0x80000, 0x800);
 		target_add_commands(t, stm32f1_cmd_list, "STM32F3");
-		return true;
-	}
-
-	t->idcode = target_mem_read32(t, DBGMCU_IDCODE_F0) & 0xfff;
-	switch(t->idcode) {
+		break;
 	case 0x444:  /* STM32F03 RM0091 Rev.7, STM32F030x[4|6] RM0360 Rev. 4*/
 		t->driver = "STM32F03";
 		flash_size = 0x8000;

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -199,11 +199,7 @@ static void stm32f7_detach(target *t)
 bool stm32f4_probe(target *t)
 {
 	ADIv5_AP_t *ap = cortexm_ap(t);
-	uint32_t idcode;
-
-	idcode = (ap->dp->targetid >> 16) & 0xfff;
-	if (!idcode)
-		idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xFFF;
+	uint32_t idcode = ap->partno;
 
 	if (idcode == ID_STM32F20X) {
 		/* F405 revision A have a wrong IDCODE, use ARM_CPUID to make the

--- a/src/target/stm32f4.c
+++ b/src/target/stm32f4.c
@@ -98,9 +98,6 @@ static int stm32f4_flash_write(struct target_flash *f,
 #define F4_FLASHSIZE	0x1FFF7A22
 #define F7_FLASHSIZE	0x1FF0F442
 #define F72X_FLASHSIZE	0x1FF07A22
-#define DBGMCU_IDCODE	0xE0042000
-#define DBGMCU_CR		0xE0042004
-#define DBG_SLEEP		(1 <<  0)
 #define ARM_CPUID	0xE000ED00
 
 #define AXIM_BASE 0x8000000
@@ -190,12 +187,6 @@ char *stm32f4_get_chip_name(uint32_t idcode)
 	}
 }
 
-static void stm32f7_detach(target *t)
-{
-	target_mem_write32(t, DBGMCU_CR, t->target_storage);
-	cortexm_detach(t);
-}
-
 bool stm32f4_probe(target *t)
 {
 	ADIv5_AP_t *ap = cortexm_ap(t);
@@ -213,8 +204,6 @@ bool stm32f4_probe(target *t)
 	case ID_STM32F74X: /* F74x RM0385 Rev.4 */
 	case ID_STM32F76X: /* F76x F77x RM0410 */
 	case ID_STM32F72X: /* F72x F73x RM0431 */
-		t->detach = stm32f7_detach;
-		/* fall through */
 	case ID_STM32F40X:
 	case ID_STM32F42X: /* 427/437 */
 	case ID_STM32F46X: /* 469/479 */
@@ -294,8 +283,6 @@ static bool stm32f4_attach(target *t)
 	target_mem_map_free(t);
 	uint32_t flashsize = target_mem_read32(t, flashsize_base) & 0xffff;
 	if (is_f7) {
-		t->target_storage = target_mem_read32(t, DBGMCU_CR);
-		target_mem_write32(t, DBGMCU_CR, DBG_SLEEP);
 		target_add_ram(t, 0x00000000, 0x4000);  /* 16 k ITCM Ram */
 		target_add_ram(t, 0x20000000, 0x20000); /* 128 k DTCM Ram */
 		target_add_ram(t, 0x20020000, 0x60000); /* 384 k Ram */

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -233,7 +233,7 @@ static void stm32h7_detach(target *t)
 bool stm32h7_probe(target *t)
 {
 	ADIv5_AP_t *ap = cortexm_ap(t);
-	uint32_t idcode = (ap->dp->targetid >> 16) & 0xfff;
+	uint32_t idcode = ap->partno;
 	if (idcode == ID_STM32H74x) {
 		t->idcode = idcode;
 		t->driver = stm32h74_driver_str;

--- a/src/target/stm32h7.c
+++ b/src/target/stm32h7.c
@@ -190,9 +190,6 @@ static bool stm32h7_attach(target *t)
 		return false;
 	/* RM0433 Rev 4 is not really clear, what bits are needed.
 	 * Set all possible relevant bits for now. */
-	uint32_t dbgmcu_cr = target_mem_read32(t, DBGMCU_CR);
-	t->target_storage = dbgmcu_cr;
-	target_mem_write32(t, DBGMCU_CR, DBGSLEEP_D1 | D1DBGCKEN);
 	/* If IWDG runs as HARDWARE watchdog (44.3.4) erase
 	 * will be aborted by the Watchdog and erase fails!
 	 * Setting IWDG_KR to 0xaaaa does not seem to help!*/
@@ -224,12 +221,6 @@ static bool stm32h7_attach(target *t)
 	return true;
 }
 
-static void stm32h7_detach(target *t)
-{
-	target_mem_write32(t, DBGMCU_CR, t->target_storage);
-	cortexm_detach(t);
-}
-
 bool stm32h7_probe(target *t)
 {
 	ADIv5_AP_t *ap = cortexm_ap(t);
@@ -238,7 +229,6 @@ bool stm32h7_probe(target *t)
 		t->idcode = idcode;
 		t->driver = stm32h74_driver_str;
 		t->attach = stm32h7_attach;
-		t->detach = stm32h7_detach;
 		target_add_commands(t, stm32h7_cmd_list, stm32h74_driver_str);
 		return true;
 	}

--- a/src/target/stm32l0.c
+++ b/src/target/stm32l0.c
@@ -169,11 +169,6 @@ static const struct command_s stm32lx_cmd_list[] = {
         { NULL, NULL, NULL },
 };
 
-enum {
-        STM32L0_DBGMCU_IDCODE_PHYS = 0x40015800,
-        STM32L1_DBGMCU_IDCODE_PHYS = 0xe0042000,
-};
-
 static bool stm32lx_is_stm32l1(target* t)
 {
         switch (t->idcode) {
@@ -270,7 +265,7 @@ bool stm32l0_probe(target* t)
 {
 	uint32_t idcode;
 
-	idcode = target_mem_read32(t, STM32L1_DBGMCU_IDCODE_PHYS) & 0xfff;
+	idcode = cortexm_ap(t)->partno;
 	switch (idcode) {
 	case 0x416:                   /* CAT. 1 device */
 	case 0x429:                   /* CAT. 2 device */
@@ -284,10 +279,6 @@ bool stm32l0_probe(target* t)
 		//stm32l_add_eeprom(t, 0x8080000, 0x4000);
 		target_add_commands(t, stm32lx_cmd_list, "STM32L1x");
 		return true;
-	}
-
-	idcode = target_mem_read32(t, STM32L0_DBGMCU_IDCODE_PHYS) & 0xfff;
-	switch (idcode) {
 	case 0x457:                   /* STM32L0xx Cat1 */
 	case 0x425:                   /* STM32L0xx Cat2 */
 	case 0x417:                   /* STM32L0xx Cat3 */

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -21,6 +21,7 @@
 #include "general.h"
 #include "target.h"
 #include "target_internal.h"
+#include "command.h"
 
 #include <stdarg.h>
 
@@ -140,7 +141,6 @@ void target_add_commands(target *t, const struct command_s *cmds, const char *na
 	tc->next = NULL;
 }
 
-extern bool connect_assert_srst;
 target *target_attach_n(int n, struct target_controller *tc)
 {
 	target *t;

--- a/src/target/target.c
+++ b/src/target/target.c
@@ -140,13 +140,16 @@ void target_add_commands(target *t, const struct command_s *cmds, const char *na
 	tc->next = NULL;
 }
 
+extern bool connect_assert_srst;
 target *target_attach_n(int n, struct target_controller *tc)
 {
 	target *t;
 	int i;
 	for(t = target_list, i = 1; t; t = t->next, i++)
-		if(i == n)
+		if(i == n) {
+			platform_srst_set_val(connect_assert_srst);
 			return target_attach(t, tc);
+		}
 	return NULL;
 }
 
@@ -157,6 +160,7 @@ target *target_attach(target *t, struct target_controller *tc)
 
 	t->tc = tc;
 
+	platform_srst_set_val(connect_assert_srst);
 	if (!t->attach(t))
 		return NULL;
 


### PR DESCRIPTION
There were two issues:

* The wrong register (DHCSR) was being checked for the sticky error bits. It should be ADIV5_DP_CTRLSTAT.
* DHCSR read (in fact, any access outside the DSU external address range) is blocked for a protected SAM device, and will cause the sticky error bit to be set, preventing any further accesses until it is cleared. (See section 12.9 of the SAM D20 datasheet: http://ww1.microchip.com/downloads/en/DeviceDoc/60001504B.pdf)
  If we find the error bit is set, we must clear it (both of which are done by adiv5_dp_error()), and then skip the attempts to halt the processor or enable tracing. A protected SAM device is guaranteed to be halted at this stage, because it will only allow a debugger to connect on reset, and keeps the processor halted indefinitely (See section 12.6.2 of the datasheet linked above).

I have only tested on SAMD51 (see #534) as this is the only SAM device I have, so I can't test if it works for SAMD20/21. Based on the datasheets, I believe they should behave the same way.

One thing I've observed is that a protected SAMD51 is detected as a Cortex M7, whereas unprotected, it's correctly listed as M3/M4. However, given there's no access to the system control registers in protected mode, there's probably no way to determine the core type.