### PR TITLE
GD32F1/G32F3 support and audodetection of ram/flash size

### DIFF
--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -670,7 +670,6 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 			return;
 		}
 	}
-
 	/* This AP reset logic is described in ADIv5, but fails to work
 	 * correctly on STM32.	CDBGRSTACK is never asserted, and we
 	 * just wait forever.  This scenario is described in B2.4.1
@@ -736,6 +735,7 @@ void adiv5_dp_init(ADIv5_DP_t *dp)
 				dp->ap_cleanup(i);
 #endif
 			adiv5_ap_unref(ap);
+			adiv5_dp_unref(dp);
 			/* FIXME: Should we expect valid APs behind duplicate ones? */
 			return;
 		}

--- a/src/target/adiv5.c
+++ b/src/target/adiv5.c
@@ -614,8 +614,10 @@ ADIv5_AP_t *adiv5_new_ap(ADIv5_DP_t *dp, uint8_t apsel)
 
 void adiv5_dp_init(ADIv5_DP_t *dp)
 {
-	/* Check IDCODE for a valid designer*/
-	if ((dp->idcode & 0xfff) == 0) {
+#define DPIDR_PARTNO_MASK 0x0ff00000
+/* Check IDCODE for a valid designer and sensible PARTNO*/
+	if (((dp->idcode & 0xfff) == 0)  ||
+		((dp->idcode & DPIDR_PARTNO_MASK)) == DPIDR_PARTNO_MASK) {
 		DEBUG_WARN("Invalid DP idcode %08" PRIx32 "\n", dp->idcode);
 		free(dp);
 		return;

--- a/src/target/adiv5.h
+++ b/src/target/adiv5.h
@@ -98,6 +98,8 @@
 /*LPC845 with designer 501. Strange!? */
 #define AP_DESIGNER_SPECULAR     0x501
 #define AP_DESIGNER_ENERGY_MICRO 0x673
+#define AP_DESIGNER_GIGADEVICE   0x751
+
 
 /* AP Control and Status Word (CSW) */
 #define ADIV5_AP_CSW_DBGSWENABLE	(1u << 31)

--- a/src/target/adiv5_jtagdp.c
+++ b/src/target/adiv5_jtagdp.c
@@ -50,8 +50,8 @@ void adiv5_jtag_dp_handler(uint8_t jd_index, uint32_t j_idcode)
 	}
 
 	dp->dp_jd_index = jd_index;
+	dp->idcode = j_idcode;
 	if ((PC_HOSTED == 0 ) || (!platform_jtag_dp_init(dp))) {
-		dp->idcode = j_idcode;
 		dp->dp_read = fw_adiv5_jtagdp_read;
 		dp->error = adiv5_jtagdp_error;
 		dp->low_access = fw_adiv5_jtagdp_low_access;

--- a/src/target/cortexm.c
+++ b/src/target/cortexm.c
@@ -387,6 +387,9 @@ bool cortexm_probe(ADIv5_AP_t *ap)
 			target_halt_resume(t, 0);
 		}
 		break;
+	case AP_DESIGNER_GIGADEVICE:
+		PROBE(gd32f1_probe);
+ 		break;
 	case AP_DESIGNER_STM:
 		PROBE(stm32f1_probe);
 		PROBE(stm32f4_probe);

--- a/src/target/stm32f1.c
+++ b/src/target/stm32f1.c
@@ -116,6 +116,38 @@ static void stm32f1_add_flash(target *t,
 	target_add_flash(t, f);
 }
 
+/**
+    \brief identify the correct gd32 f1/f3 chip
+    GD32 : STM32 compatible chip
+*/
+bool gd32f1_probe(target *t)
+{
+	uint16_t stored_idcode = t->idcode;
+    // M3 & M4 & riscV only afaik
+    t->idcode = target_mem_read32(t, DBGMCU_IDCODE) & 0xfff;
+    uint32_t signature= target_mem_read32(t, FLASHSIZE);
+    uint32_t flashSize=signature & 0xFFFF;
+    uint32_t ramSize=signature >>16 ;
+	switch(t->idcode) {
+	case 0x414:  /* Gigadevice gd32f303 */
+		t->driver = "GD32F3";
+        break;
+	case 0x410:  /* Gigadevice gd32f103 */
+ 		t->driver = "GD32F1";
+        break;
+	default:
+  		t->idcode = stored_idcode;
+		return false;
+	}
+    target_add_ram(t, 0x20000000, ramSize*1024);
+    stm32f1_add_flash(t, 0x8000000, flashSize*1024, 0x400);
+    target_add_commands(t, stm32f1_cmd_list, t->driver);
+    return true;
+}
+/**
+    \brief identify the stm32f1 chip
+*/
+
 bool stm32f1_probe(target *t)
 {
 	uint16_t stored_idcode = t->idcode;

--- a/src/target/target_internal.h
+++ b/src/target/target_internal.h
@@ -169,6 +169,7 @@ int tc_system(target *t, target_addr cmd, size_t cmdlen);
 /* Probe for various targets.
  * Actual functions implemented in their respective drivers.
  */
+bool gd32f1_probe(target *t);
 bool stm32f1_probe(target *t);
 bool stm32f4_probe(target *t);
 bool stm32h7_probe(target *t);


### PR DESCRIPTION
Rebased patch to add support for GD32F103 and GD32F303
The flash & ram size are autoprobed using the chip registers
